### PR TITLE
Add keywords for border types as listed in POD in Writer/Excel.pm

### DIFF
--- a/lib/Spreadsheet/Template/Writer/Excel.pm
+++ b/lib/Spreadsheet/Template/Writer/Excel.pm
@@ -241,7 +241,20 @@ sub _munge_format {
     my ($format) = @_;
 
     my %border = (
-        thin => 1,
+        none                => 0,
+        thin                => 1,
+        medium              => 2,
+        dashed              => 3,
+        dotted              => 4,
+        thick               => 5,
+        double              => 6,
+        hair                => 7,
+        medium_dashed       => 8,
+        dash_dot            => 9,
+        medium_dash_dot     => 10,
+        dash_dot_dot        => 11,
+        medium_dash_dot_dot => 12,
+        slant_dash_dot      => 13,
     );
 
     my $properties = { %$format };


### PR DESCRIPTION
I noticed no matter what I had in the border sections of my template, if I had something there my XLSX output had all four thin borders on the cell.  In particular I was shooting for partial borders because I'm testing with a template generated from a fully formatted spreadsheet which uses that option heavily.

It looks like these were just forgotten and with %border filled, the code that follows works as expected.  The existing tests only look for no borders or all thin borders, and the generator handles all the border types, so I figured it was just forgotten on the flip side here.

I wanted to provide tests for partial borders and border colors and styles, but after editing t/data/Test.json I realized that you are actually sourcing from Test.xlsx and I didn't want to mangle it somehow by using LOcalc if you intend for that file to be something definitely out of Excel or something.  I can work on another PR for that if desired.
