### PR TITLE
make json an attr to allow dependency injection

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@ Revision history for Spreadsheet-Template
 
 {{$NEXT}}
 
+      - add json as a param instead of hardcoding from_json.
+
 0.04  2014-09-10
       - support more border types (merrilymeredith, #5)
 

--- a/lib/Spreadsheet/Template.pm
+++ b/lib/Spreadsheet/Template.pm
@@ -404,6 +404,20 @@ has _processor => (
     },
 );
 
+=attr json
+
+Instance of a JSON class that will handle decoding. Defaults to an instance of L<JSON>.
+Passing in a JSON obj with ->relaxed(1) set will allow for trailing commas in your templates.
+
+=cut
+
+has json => (
+    is => 'ro',
+    default => sub {
+        return JSON->new;
+    }
+);
+
 sub _writer {
     my $self = shift;
     my $class = $self->writer_class;
@@ -426,7 +440,7 @@ sub render {
     my $contents = $self->_processor->process($template, $vars);
     # not decode_json, since we expect that we are already being handed a
     # character string (decode_json also decodes utf8)
-    my $data = from_json($contents);
+    my $data = $self->json->decode($contents);
     return $self->_writer->write($data);
 }
 


### PR DESCRIPTION
I was mucking around trying to figure out how to eliminate the trailing comma in a for loop of excel rows when I figured it'd be much easier to use relaxed mode in JSON, leading to this pr which allows you to pass in json as an attribute.
I could see adding a 'json_relaxed' attr instead but I kind of like the ability to pass in ones favorite JSON decoder. Let me know if there's something I should change or if I totally missed something.